### PR TITLE
Fix destroy didn't delete all data in the store

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -797,7 +797,7 @@ Model.prototype.save = function(obj, callback){
 */
 
 Model.prototype.destroy = function(){
-  this._store.length = 0;
+  this._store.destroy();
   this._index.length = 0;
 
   return this;

--- a/lib/store.js
+++ b/lib/store.js
@@ -55,4 +55,16 @@ var Store = module.exports = function(obj){
   this.remove = function(id){
     delete store[id];
   };
+
+  /**
+   * Deletes all elements in the store.
+   *
+   * @method destroy
+   */
+
+  this.destroy = function() {
+    for (var id in store) {
+      this.remove(id);
+    }
+  };
 };

--- a/test/model.js
+++ b/test/model.js
@@ -525,4 +525,17 @@ describe('Model', function(){
 
     User.filter(callback)._index.should.eql(index);
   });
+
+  it('destroy()', function() {
+    Post.destroy();
+    var query = Post.find({});
+    query.should.have.length(0);
+    query.toArray().should.be.empty;
+
+    // Retrieve model instance by using `db.model('modelName')` method,
+    //    ensure that all data has been deleted from the store.
+    query = db.model('Post').find({});
+    query.should.have.length(0);
+    query.toArray().should.be.empty;
+  });
 });


### PR DESCRIPTION
Hi, tommy. 

There is a problem, after I delete data by using `model.destroy()`, I can get to the data before by using `db.model('modelName').find({})`. So I can't do validation in the `pre` hook, for example:

``` javascript
UserSchema.pre('save', function(user, next) {
  var exists = db.model('User').findOne({ name: user.name });
  if (exists) {
    return next(new Error('User name already exists');
  }

  next();
});

// ...

var User = db.model('User', UserSchema);
User.insert({ name: 'heroic' });
User.insert({ name: 'heroic' });  // throw an error, expected
User.destroy();
User.insert({ name: 'heroic' });   // throw an error, unexpected
```
