### PR TITLE
Create ExportStream

### DIFF
--- a/lib/ExportStream.js
+++ b/lib/ExportStream.js
@@ -1,0 +1,149 @@
+'use strict';
+const pkg = require('../package.json');
+const { Readable } = require('stream');
+const { inherits } = require('util');
+
+/**
+ * @class
+ * @extends Readable
+ * @param {Database} db
+ * @internal
+ */
+const WarehouseExportReadableStream = function(db) {
+  Readable.call(this);
+  const models = this.models = db._models;
+  const keys = this.ModelsKeys = Object.keys(models).filter(key => models[key] != null);
+  const { length } = keys;
+
+  /**
+   * state: -1
+   *   No Pushed.
+   * state: 0
+   *   Pushed Meta.
+   * state: 1
+   *   Partial Pushed Models.
+   * state: 2
+   *   Model has been pausing during export.
+   * state: 3
+   *   All Pushed Models.
+   * state: 4
+   *   All Pushed(Ended).
+   */
+  this.state = -1;
+  this.ExportedModelCount = 0;
+  this.ModelsLength = length;
+  this.meta = {
+    version: db.options.version,
+    warehouse: pkg.version
+  };
+
+  /**
+   * use only state 2.
+   * Stach exporting model.
+   * @type {Model}
+   */
+  this.stashedModel = undefined;
+
+  /**
+   * use only state 2.
+   * Stach exporting index.
+   */
+  this.stashedDatasIndex = -1;
+
+  /**
+   * use only state 2.
+   * Stach exporting  datas.
+   * @type {string[]|undefined}
+   */
+  this.stashedDatasKeys = undefined;
+};
+
+inherits(WarehouseExportReadableStream, Readable);
+
+WarehouseExportReadableStream.prototype.stashModelDatas = function(model, keys, index) {
+  this.state = 2;
+  this.stashedModel = model;
+  this.stashedDatasKeys = keys;
+  this.stashedDatasIndex = index;
+};
+
+WarehouseExportReadableStream.prototype.drowStashedmodelDatas = function() {
+  const model = this.stashedModel;
+  const datasKeys = this.stashedDatasKeys;
+  const index = this.stashedDatasIndex;
+
+  this.stashedModel = undefined;
+  this.stashedDatasKeys = undefined;
+  this.stashedDatasIndex = -1;
+  this.state = 0;
+
+  return [model, datasKeys, index];
+};
+
+WarehouseExportReadableStream.prototype._read = function() {
+  switch (this.state) {
+    case -1:
+      // Bigin Json Object And Bigin Meta
+      this.push('{"meta":');
+      this.push(JSON.stringify(this.meta));
+      // End Meta And Bigin Models
+      this.push(',"models":{');
+      this.state = this.ModelsLength > 0 ? 0 : 3;
+      return;
+    case 1:
+      // Key/Value pair Concat
+      this.push(',');
+    case 0: // eslint-disable-line no-fallthrough
+    case 2: {
+      // Export Models
+      let model, datasKeys, index;
+
+      if (this.state === 2) {
+        // Stash
+        [model, datasKeys, index] = this.drowStashedmodelDatas();
+      } else {
+        // first
+        const key = this.ModelsKeys[this.ExportedModelCount];
+
+        model = this.models[key];
+        datasKeys = Object.keys(model.data).filter(id => model.has(id));
+        index = -1;
+
+        this.push('"'); // Bigin Key
+        this.push(key);
+        this.push('":['); // End Key And Key/Value Separator And Bigin Array
+      }
+
+      const { length } = datasKeys;
+
+      while (++index < length) {
+        if (index > 0) this.push(','); // Concat
+
+        const doc = model.findById(datasKeys[index], { lean: true });
+        const exportData = model.schema._exportDatabase(doc);
+
+        if (!this.push(JSON.stringify(exportData))) {
+          this.stashModelDatas(model, datasKeys, index);
+          return;
+        }
+      }
+
+      this.push(']'); // End Array
+
+      this.state = ++this.ExportedModelCount >= this.ModelsLength ? 3 : 1;
+      return;
+    }
+    case 3:
+      // End Models And End JSON Object
+      this.push('}}');
+      this.push(null);
+      this.state = 4;
+      return;
+    case 4:
+      return;
+    default:
+      throw new Error('invalid State.');
+  }
+};
+
+module.exports = WarehouseExportReadableStream;

--- a/lib/database.js
+++ b/lib/database.js
@@ -9,6 +9,7 @@ const SchemaType = require('./schematype');
 const util = require('./util');
 const WarehouseError = require('./error');
 const pkg = require('../package.json');
+const ExportStream = require('./ExportStream');
 
 /**
  * Database constructor.
@@ -108,45 +109,14 @@ Database.prototype.load = function(callback) {
  * @return {Promise}
  */
 Database.prototype.save = function(callback) {
-  const path = this.options.path;
+  const { path } = this.options;
 
   if (!path) throw new WarehouseError('options.path is required');
 
   return new Promise((resolve, reject) => {
-    const stream = fs.createWriteStream(path);
-
-    // Start
-    stream.write('{');
-
-    // Meta
-    stream.write(`"meta":${JSON.stringify({
-      version: this.options.version,
-      warehouse: pkg.version
-    })},`);
-
-    // Export models
-    const models = this._models;
-    const keys = Object.keys(models);
-
-    stream.write('"models":{');
-
-    for (let i = 0, len = keys.length; i < len; i++) {
-      const key = keys[i];
-      const model = models[key];
-
-      if (!model) continue;
-
-      if (i) stream.write(',');
-      stream.write(`"${key}":${model._export()}`);
-    }
-
-    stream.write('}');
-
-    // End
-    stream.end('}');
-
-    stream.on('error', reject)
-      .on('finish', resolve);
+    const readable = new ExportStream(this);
+    const stream = fs.createWriteStream(path, 'utf8');
+    readable.once('error', reject).pipe(stream).once('error', reject).once('finish', resolve);
   }).asCallback(callback);
 };
 


### PR DESCRIPTION
The current `Warehouse#save()` uses stream, but it is not controlled by `highWatarMark` and is forcibly added to the internal buffer of stream.
Therefore, memory exhaustion can not be avoided in the current implementation.
In order to avoid this, `Readable` is mainly required, but it is necessary to frequently add it so that the internal queue is not clogged up.
As a result of doing that control, the code has become quite long by just implementing `Readable`.