### PR TITLE
Change stream used inside "Warehouse#save()" to correspond to backpressure.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -9,6 +9,7 @@ const SchemaType = require('./schematype');
 const util = require('./util');
 const WarehouseError = require('./error');
 const pkg = require('../package.json');
+const JsonReadable = require('json-stream-stringify');
 
 /**
  * Database constructor.
@@ -108,46 +109,33 @@ Database.prototype.load = function(callback) {
  * @return {Promise}
  */
 Database.prototype.save = function(callback) {
-  const path = this.options.path;
+  const { path } = this.options;
 
   if (!path) throw new WarehouseError('options.path is required');
 
+  const rs = new JsonReadable(this);
+
+  const ws = fs.createWriteStream(path);
+
   return new Promise((resolve, reject) => {
-    const stream = fs.createWriteStream(path);
+    rs.once('error', reject).pipe(ws).once('error', reject).once('finish', resolve);
+  }).asCallback(callback);
+};
 
-    // Start
-    stream.write('{');
+Database.prototype.toJSON = function() {
+  const models = Object.keys(this._models)
+    .reduce((obj, key) => {
+      const value = this._models[key];
+      if (value != null) obj[key] = value;
+      return obj;
+    }, {});
 
-    // Meta
-    stream.write(`"meta":${JSON.stringify({
+  return {
+    meta: {
       version: this.options.version,
       warehouse: pkg.version
-    })},`);
-
-    // Export models
-    const models = this._models;
-    const keys = Object.keys(models);
-
-    stream.write('"models":{');
-
-    for (let i = 0, len = keys.length; i < len; i++) {
-      const key = keys[i];
-      const model = models[key];
-
-      if (!model) continue;
-
-      if (i) stream.write(',');
-      stream.write(`"${key}":${model._export()}`);
-    }
-
-    stream.write('}');
-
-    // End
-    stream.end('}');
-
-    stream.on('error', reject)
-      .on('finish', resolve);
-  }).asCallback(callback);
+    }, models
+  };
 };
 
 Database.Schema = Database.prototype.Schema = Schema;

--- a/lib/model.js
+++ b/lib/model.js
@@ -957,14 +957,11 @@ Model.prototype._import = function(arr) {
  * @private
  */
 Model.prototype._export = function() {
-  const arr = new Array(this.length);
-  const schema = this.schema;
+  return JSON.stringify(this);
+};
 
-  this.forEach((item, i) => {
-    arr[i] = schema._exportDatabase(item);
-  }, {lean: true});
-
-  return JSON.stringify(arr);
+Model.prototype.toJSON = function() {
+  return this.map(item => this.schema._exportDatabase(item), {lean: true});
 };
 
 module.exports = Model;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cuid": "~1.3.8",
     "graceful-fs": "^4.1.3",
     "is-plain-object": "^2.0.1",
+    "json-stream-stringify": "^2.0.0",
     "lodash": "^4.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When using Warehouse#save(), due to its characteristics, it may cause memory exhaustion if it does not correspond to [backpressure](https://nodejs.org/en/docs/guides/backpressuring-in-streams/).

It is simple in the current implementation, but if backpressure is not supported, it is faster to use fs.writeFile().
Corresponding to backpressure means reducing memory to use as much as possible, not sending information more than necessary to Writable, interrupting processing as soon as possible when Writable asks for interruption is.
To deal with these we have added dependencies on the "json-stream-stringify" library.