### PR TITLE
refactor: use instanceof Date instead of util.isDate

### DIFF
--- a/lib/types/date.js
+++ b/lib/types/date.js
@@ -30,7 +30,7 @@ util.inherits(SchemaTypeDate, SchemaType);
 SchemaTypeDate.prototype.cast = function(value_, data) {
   const value = SchemaType.prototype.cast.call(this, value_, data);
 
-  if (value == null || util.isDate(value)) return value;
+  if (value == null || value instanceof Date) return value;
 
   return new Date(value);
 };
@@ -45,7 +45,7 @@ SchemaTypeDate.prototype.cast = function(value_, data) {
 SchemaTypeDate.prototype.validate = function(value_, data) {
   const value = SchemaType.prototype.validate.call(this, value_, data);
 
-  if (value != null && (!util.isDate(value) || isNaN(value.getTime()))) {
+  if (value != null && (!(value instanceof Date) || isNaN(value.getTime()))) {
     throw new ValidationError(`\`${value}\` is not a valid date!`);
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,6 @@
 const util = require('util');
 
 exports.inherits = util.inherits;
-exports.isDate = util.isDate;
 
 exports.shuffle = array => {
   if (!Array.isArray(array)) throw new TypeError('array must be an Array!');


### PR DESCRIPTION
## Proposal

use `instanceof Date` instead of `util.isDate`

## Reason

`util.isDate` is deprecated in node v4.
Please see node v4 [change log](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#2015-09-08-version-400-stable-rvagg)