### PR TITLE
Streaming Warehouse#save()

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -9,6 +9,54 @@ const SchemaType = require('./schematype');
 const WarehouseError = require('./error');
 const pkg = require('../package.json');
 
+const uncorkAsync = stream => new Promise(resolve => {
+  process.nextTick(() => {
+    stream.uncork();
+    resolve();
+  });
+});
+
+const exportAsync = Promise.coroutine(function* (database, path) {
+  const stream = fs.createWriteStream(path);
+
+  // Start body & Meta & Start models
+  stream.write(`{"meta":${JSON.stringify({
+    version: database.options.version,
+    warehouse: pkg.version
+  })},"models":{`);
+
+  const models = database._models;
+  const keys = Object.keys(models);
+  const { length } = keys;
+
+  // support stream backpressure
+  const writeAsync = Promise.promisify(stream.write, { context: stream });
+
+  // models body
+  for (let i = 0; i < length; i++) {
+    const key = keys[i];
+
+    if (!models[key]) continue;
+
+    stream.cork();
+    if (i) stream.write(',', 'ascii');
+
+    stream.write(`"${key}":`);
+
+    const modelExportPromise = writeAsync(models[key]._export());
+
+    yield uncorkAsync(stream);
+    yield modelExportPromise;
+  }
+
+  // End models
+  stream.end('}}', 'ascii');
+  return new Promise((resolve, reject) => {
+    stream.on('error', reject)
+      .on('finish', resolve);
+  });
+});
+
 class Database {
 
   /**
@@ -110,45 +158,7 @@ class Database {
     const { path } = this.options;
 
     if (!path) throw new WarehouseError('options.path is required');
-
-    return new Promise((resolve, reject) => {
-      const stream = fs.createWriteStream(path);
-
-      // Start
-      stream.write('{');
-
-      // Meta
-      stream.write(`"meta":${JSON.stringify({
-        version: this.options.version,
-        warehouse: pkg.version
-      })},`);
-
-      // Export models
-
-      stream.write('"models":{');
-
-      const models = this._models;
-      const keys = Object.keys(models);
-      const { length } = keys;
-
-      for (let i = 0; i < length; i++) {
-        const key = keys[i];
-        const model = models[key];
-
-        if (!model) continue;
-
-        if (i) stream.write(',');
-        stream.write(`"${key}":${model._export()}`);
-      }
-
-      stream.write('}');
-
-      // End
-      stream.end('}');
-
-      stream.on('error', reject)
-        .on('finish', resolve);
-    }).asCallback(callback);
+    return exportAsync(this, path).asCallback(callback);
   }
 
   toJSON() {

--- a/lib/model.js
+++ b/lib/model.js
@@ -933,9 +933,10 @@ class Model extends EventEmitter {
   }
 
   toJSON() {
-    const { data, schema, length } = this;
-    const result = new Array(length);
+    const result = new Array(this.length);
+    const { data, schema } = this;
     const keys = Object.keys(data);
+    const { length } = keys;
 
     for (let i = 0, num = 0; i < length; i++) {
       const raw = data[keys[i]];

--- a/lib/model.js
+++ b/lib/model.js
@@ -642,10 +642,16 @@ class Model extends EventEmitter {
    */
   map(iterator, options) {
     const result = new Array(this.length);
+    const keys = Object.keys(this.data);
+    const len = keys.length;
 
-    this.forEach((item, i) => {
-      result[i] = iterator(item, i);
-    }, options);
+    for (let i = 0, num = 0; i < len; i++) {
+      const data = this.findById(keys[i], options);
+      if (data) {
+        result[num] = iterator(data, num);
+        num++;
+      }
+    }
 
     return result;
   }
@@ -923,11 +929,21 @@ class Model extends EventEmitter {
    * @private
    */
   _export() {
-    return JSON.stringify(this);
+    return JSON.stringify(this.toJSON());
   }
 
   toJSON() {
-    return this.map(item => this.schema._exportDatabase(item), {lean: true});
+    const { data, schema, length } = this;
+    const result = new Array(length);
+    const keys = Object.keys(data);
+
+    for (let i = 0, num = 0; i < length; i++) {
+      const raw = data[keys[i]];
+      if (raw) {
+        result[num++] = schema._exportDatabase(cloneDeep(raw));
+      }
+    }
+    return result;
   }
 }
 

--- a/test/fixtures/db.json
+++ b/test/fixtures/db.json
@@ -1,1 +1,1 @@
-{"meta":{"version":1,"warehouse":"2.2.0"},"models":{"Test":[{"_id":"A"},{"_id":"B"},{"_id":"C"}]}}
+{"meta":{"version":1,"warehouse":"3.0.1"},"models":{"Test":[{"_id":"A"},{"_id":"B"},{"_id":"C"}]}}


### PR DESCRIPTION
This PR is a continuation of #62 .
One reason for the poor memory performance of #22 was that there was one `Readable` and one `Writable`, which were connected by a `pipe()`.
Since only one Stream is a huge object, we thought the possibility that the increase in `Readable` led to memory pressure.
The purpose of this PR is to verify whether memory consumption can be reduced while implementing interruption / resumption of processing by `Bluebird.coroutine()`.
I don't know the details of the method of performance testing, but at least the testing of the Warehouse alone did not change the processing speed significantly.