### PR TITLE
refactor: use rfdc to replace lodash

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const cloneDeep = require('lodash/cloneDeep');
+const cloneDeep = require('rfdc')();
 
 class Document {
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { EventEmitter } = require('events');
-const cloneDeep = require('lodash/cloneDeep');
+const cloneDeep = require('rfdc')();
 const Promise = require('bluebird');
 const { parseArgs, getProp, setGetter, shuffle } = require('./util');
 const Document = require('./document');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -652,7 +652,7 @@ class Schema {
    * @private
    */
   _parseUpdate(updates) {
-    return (new UpdateParser(this.paths)).parseUpdate(updates);
+    return new UpdateParser(this.paths).parseUpdate(updates);
   }
 
   /**
@@ -663,7 +663,7 @@ class Schema {
    * @private
    */
   _execQuery(query) {
-    return (new QueryParser(this.paths)).execQuery(query);
+    return new QueryParser(this.paths).execQuery(query);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cuid": "^2.1.4",
     "graceful-fs": "^4.1.3",
     "is-plain-object": "^3.0.0",
-    "lodash": "^4.17.10"
+    "rfdc": "^1.1.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -37,6 +37,7 @@
     "eslint": "^6.1.0",
     "eslint-config-hexo": "^3.0.0",
     "jsdoc": "^3.4.0",
+    "lodash": "^4.17.15",
     "minami": "^1.1.1",
     "mocha": "^6.0.2",
     "nyc": "^14.1.1",


### PR DESCRIPTION
https://www.npmjs.com/package/rfdc

According to the [benchmark](https://github.com/davidmarkclements/rfdc#benchmarks) performed by rfdc. it is at least 3x more faster than lodash cloneDeep.