### PR TITLE
perf(utils): improve getProp(), setProp(), delProp(), setGetter() performance

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,11 +27,13 @@ exports.getProp = (obj, key) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
-  const token = extractPropKey(key);
-  let result = obj[token.shift()];
-  const len = token.length;
+  if (key.indexOf('.') < 0) {
+    return obj[key];
+  }
 
-  if (!len) return result;
+  const token = extractPropKey(key);
+  let result = obj;
+  const len = token.length;
 
   for (let i = 0; i < len; i++) {
     result = result[token[i]];
@@ -44,14 +46,14 @@ exports.setProp = (obj, key, value) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
+  if (key.indexOf('.') < 0) {
+    obj[key] = value;
+    return;
+  }
+
   const token = extractPropKey(key);
   const lastKey = token.pop();
   const len = token.length;
-
-  if (!len) {
-    obj[lastKey] = value;
-    return;
-  }
 
   let cursor = obj;
 
@@ -68,14 +70,14 @@ exports.delProp = (obj, key) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
+  if (key.indexOf('.') < 0) {
+    delete obj[key];
+    return;
+  }
+
   const token = extractPropKey(key);
   const lastKey = token.pop();
   const len = token.length;
-
-  if (!len) {
-    delete obj[lastKey];
-    return;
-  }
 
   let cursor = obj;
 
@@ -97,14 +99,14 @@ exports.setGetter = (obj, key, fn) => {
   if (!key) throw new TypeError('key is required!');
   if (typeof fn !== 'function') throw new TypeError('fn must be a function!');
 
+  if (key.indexOf('.') < 0) {
+    obj.__defineGetter__(key, fn);
+    return;
+  }
+
   const token = extractPropKey(key);
   const lastKey = token.pop();
   const len = token.length;
-
-  if (!len) {
-    obj.__defineGetter__(lastKey, fn);
-    return;
-  }
 
   let cursor = obj;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,7 +27,7 @@ exports.getProp = (obj, key) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
-  if (key.indexOf('.') < 0) {
+  if (!key.includes('.')) {
     return obj[key];
   }
 
@@ -46,7 +46,7 @@ exports.setProp = (obj, key, value) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
-  if (key.indexOf('.') < 0) {
+  if (!key.includes('.')) {
     obj[key] = value;
     return;
   }
@@ -70,7 +70,7 @@ exports.delProp = (obj, key) => {
   if (typeof obj !== 'object') throw new TypeError('obj must be an object!');
   if (!key) throw new TypeError('key is required!');
 
-  if (key.indexOf('.') < 0) {
+  if (!key.includes('.')) {
     delete obj[key];
     return;
   }
@@ -99,7 +99,7 @@ exports.setGetter = (obj, key, fn) => {
   if (!key) throw new TypeError('key is required!');
   if (typeof fn !== 'function') throw new TypeError('fn must be a function!');
 
-  if (key.indexOf('.') < 0) {
+  if (!key.includes('.')) {
     obj.__defineGetter__(key, fn);
     return;
   }


### PR DESCRIPTION
I found that on a huge site, the execution time of `String.split() / extractPropKey()` is very long.

```js
function extractPropKey(key) {
  return key.split('.');
}
```
(https://github.com/hexojs/warehouse/blob/master/lib/util.js#L22-L24)


A benchmark using a hexo dummy website (with 300 posts): (clone https://github.com/SukkaLab/hexo-many-posts.git)

- `extractPropKey()` has been called for 7,201,086 times. 

- For input values, they are all simple keys without "."
```
3325949  tag_id
2474477  post_id
 894848  _id
 178803  name
 131535  category_id
  17070  path
  16950  permalink
  16936  slug
  14418  length
  12964  date
  12490  posts
   9722  source
   7588  modified
   7468  hash
   6580  parent
   5084  published
   4460  updated
   4460  title
   4460  raw
   4460  layout
   4460  full_source
   4460  comments
   4460  _content
   4446  tags
   4446  photos
   4446  link
   4446  categories
   4446  asset_dir
   3820  more
   3820  excerpt
   3820  content
   3174  id
    120  renderable
```

A benchmark using a hexo dummy website (with 1500 posts): (clone https://github.com/SukkaLab/hexo-many-posts.git 5 times)

- Execution Time of `extractPropKey()`: **19.78**s
<img width="1291" alt="2019121701" src="https://user-images.githubusercontent.com/51783821/70974582-0b736b80-20e3-11ea-8e80-e36470ab37ec.png">


### Solution

**This PR skips the call to `split()` and for-loops, handle simple keys directly.**



