### PR TITLE
Fix bug that a resource leak

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -134,7 +134,10 @@ class Database {
     const rs = fs.createReadStream(path, 'utf8');
 
     const promise = new Promise((resolve, reject) => {
-      parseStream.once('error', reject);
+      parseStream.once('error', err => {
+        rs.destroy(err);
+        reject(err);
+      });
       parseStream.once('end', resolve);
 
       rs.once('error', reject);


### PR DESCRIPTION
Fixed a bug that a resource leak occurs without being notified to readStream when a json parse error occurs in `Database#load()`.
In hexojs/hexo#3975, this bug causes `fs.unlink()` to be called when `Database#load()` fails in [the Windows environment, but it is not deleted immediately and an EPERM error occurs](https://github.com/nodejs/node-v0.x-archive/issues/7164#issuecomment-35752024).
