### PR TITLE
chore: bump to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Simple JSON-based database",
   "main": "lib/database",
   "directories": {


### PR DESCRIPTION
refs: #83 

I'm going to release `4.0.0` after merge this PR.