### PR TITLE
fix(workaround): RangeError: Invalid string length

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -54,13 +54,13 @@ async function exportAsync(database, path) {
 
     // End models
     await handle.write('}}');
-  } catch(e) {
+  } catch (e) {
     log.error(e);
-    if (e instanceof RangeError && e.message.includes("Invalid string length")) {
+    if (e instanceof RangeError && e.message.includes('Invalid string length')) {
       // NOTE:  Currently, we can't deal with anything about this issue.
       //        If do not `catch` the exception after the process will not work (e.g: `after_generate` filter.)
       //        A side-effect of this workaround is the `db.json` will not generate.
-      log.warn("see: https://github.com/nodejs/node/issues/35973");
+      log.warn('see: https://github.com/nodejs/node/issues/35973');
     } else {
       throw e;
     }

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,6 +10,7 @@ const WarehouseError = require('./error');
 const pkg = require('../package.json');
 const { open } = fs.promises;
 const pipeline = Promise.promisify(require('stream').pipeline);
+const log = require('hexo-log')();
 
 let _writev;
 
@@ -53,6 +54,16 @@ async function exportAsync(database, path) {
 
     // End models
     await handle.write('}}');
+  } catch(e) {
+    log.error(e);
+    if (e instanceof RangeError && e.message.includes("Invalid string length")) {
+      // NOTE:  Currently, we can't deal with anything about this issue.
+      //        If do not `catch` the exception after the process will not work (e.g: `after_generate` filter.)
+      //        A side-effect of this workaround is the `db.json` will not generate.
+      log.warn("see: https://github.com/nodejs/node/issues/35973");
+    } else {
+      throw e;
+    }
   } finally {
     await handle.close();
   }

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "JSONStream": "^1.0.7",
     "bluebird": "^3.2.2",
     "cuid": "^2.1.4",
     "graceful-fs": "^4.1.3",
+    "hexo-log": "^3.0.0",
     "is-plain-object": "^5.0.0",
+    "JSONStream": "^1.0.7",
     "rfdc": "^1.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## What is this?

It the user has a many & huge posts. The `JSON.stringify` throw the `RangeError`. The error caused by V8 constraint.

> refs: https://github.com/hexojs/hexo/issues/4922

## Workaround

 `catch` the exception type of `RangeError` before `save` to `db.json`.
A side-effect of this workaround is the `db.json` will not generate.

## Others

I assume currently, we can't deal with anything about this issue (`Stream` are may effective but I did not try to implement it.) . 