### PR TITLE
feat: add skip `load` and `save` option

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -73,8 +73,8 @@ class Database {
     this.options = Object.assign({
       version: 0,
       onUpgrade() {},
-
-      onDowngrade() {}
+      onDowngrade() {},
+      dump: true
     }, options);
 
     this._models = {};
@@ -110,9 +110,12 @@ class Database {
    * @return {Promise}
    */
   load(callback) {
-    const { path, onUpgrade, onDowngrade, version: newVersion } = this.options;
+    const { path, onUpgrade, onDowngrade, version: newVersion, dump } = this.options;
 
     if (!path) throw new WarehouseError('options.path is required');
+    if (!dump) {
+      return Promise.resolve().asCallback(callback);
+    }
 
     let oldVersion = 0;
 
@@ -150,9 +153,12 @@ class Database {
    * @return {Promise}
    */
   save(callback) {
-    const { path } = this.options;
+    const { path, dump } = this.options;
 
     if (!path) throw new WarehouseError('options.path is required');
+    if (!dump) {
+      return Promise.resolve().asCallback(callback);
+    }
     return Promise.resolve(exportAsync(this, path)).asCallback(callback);
   }
 

--- a/test/scripts/database.js
+++ b/test/scripts/database.js
@@ -85,6 +85,16 @@ describe('Database', () => {
     });
   });
 
+  it('load() - without dump', () => {
+    const db = new Database({path: DB_PATH, dump: false});
+
+    return db.load().then(() => {
+      const Test = db.model('Test');
+
+      Test.toArray().should.eql([]);
+    });
+  });
+
   it('save()', () => db.save().then(() => fs.readFileAsync(DB_PATH, 'utf8')).then(data => {
     const json = JSON.parse(data);
 
@@ -101,4 +111,12 @@ describe('Database', () => {
       ]
     });
   }));
+
+  it('save() - without dump', () => {
+    const DB_PATH = path.join(path.dirname(__dirname), 'fixtures', 'db-without-dump.json');
+    const db = new Database({path: DB_PATH, dump: false});
+
+    db.save();
+    fs.existsSync(DB_PATH).should.eql(false);
+  });
 });


### PR DESCRIPTION
## What is this?

I submitted #123 PR for huge posts.
However sometimes `hexo` is no need to `load` from `db.json`. Also `save` to `db.json`.

e.g: Execute `hexo g` in GitHub Actions.

This PR purpose is to add an option for ignore them.