### PR TITLE
fix: replace `JSONStream` with `jsonstream-next`

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const JSONStream = require('JSONStream');
+const JSONStream = require('jsonstream-next');
 const Promise = require('bluebird');
 const fs = require('graceful-fs');
 const Model = require('./model');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "graceful-fs": "^4.1.3",
     "hexo-log": "^3.0.0",
     "is-plain-object": "^5.0.0",
-    "JSONStream": "^1.0.7",
+    "jsonstream-next": "^3.0.0",
     "rfdc": "^1.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR resolves hexojs/hexo#5022.

---

[`jsonstream-next`](https://github.com/yocontra/JSONStream) is a fork of [`JSONStream`](https://github.com/dominictarr/JSONStream), and the former is adapted to the new version of Node.js, while the latter has long been archived. Therefore, I recommend switching to `jsonstream-next`, to solve the problem described in hexojs/hexo#5022.