### PR TITLE
chore(deps): use `cuid2` instead of `cuid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "author": "Tommy Chen <tommy351@gmail.com> (https://zespia.tw)",
   "license": "MIT",
   "dependencies": {
+    "@paralleldrive/cuid2": "^2.0.1",
     "bluebird": "^3.7.2",
-    "cuid": "^2.1.8",
     "graceful-fs": "^4.2.10",
     "hexo-log": "^4.0.1",
     "is-plain-object": "^5.0.0",

--- a/src/types/cuid.ts
+++ b/src/types/cuid.ts
@@ -1,5 +1,5 @@
 import SchemaType from '../schematype';
-import cuid from 'cuid';
+import { createId, getConstants } from '@paralleldrive/cuid2';
 import ValidationError from '../error/validation';
 
 /**
@@ -16,20 +16,20 @@ class SchemaTypeCUID extends SchemaType<string> {
    */
   cast(value?) {
     if (value == null && this.options.required) {
-      return cuid();
+      return createId();
     }
 
     return value;
   }
 
   /**
-   * Validates data. A valid CUID must be started with `c` and 25 in length.
+   * Validates data. A valid CUID must be 24 in length.
    *
    * @param {*} value
    * @return {String|Error}
    */
   validate(value?) {
-    if (value && (value[0] !== 'c' || value.length !== 25)) {
+    if (value && (value.length !== getConstants().defaultLength)) {
       throw new ValidationError(`\`${value}\` is not a valid CUID`);
     }
 

--- a/test/scripts/model.ts
+++ b/test/scripts/model.ts
@@ -7,7 +7,7 @@ import lodash from 'lodash';
 const { sortBy } = lodash;
 import Promise from 'bluebird';
 import sinon from 'sinon';
-import cuid from 'cuid';
+import { createId } from '@paralleldrive/cuid2';
 import Database from '../../dist/database';
 
 describe('Model', () => {
@@ -193,7 +193,7 @@ describe('Model', () => {
   }).then(data => User.removeById(data._id)));
 
   it('save() - sync problem', () => {
-    const id = cuid();
+    const id = createId();
 
     return Promise.all([
       User.save({_id: id, age: 1}),

--- a/test/scripts/types/cuid.ts
+++ b/test/scripts/types/cuid.ts
@@ -17,7 +17,7 @@ describe('SchemaTypeCUID', () => {
   });
 
   it('validate()', () => {
-    type.validate('ch72gsb320000udocl363eofy').should.eql('ch72gsb320000udocl363eofy');
+    type.validate('ch72gsb320000udocl363eof').should.eql('ch72gsb320000udocl363eof');
 
     (() => type.validate('foo')).should.to.throw(ValidationError, '`foo` is not a valid CUID');
   });


### PR DESCRIPTION
## Why

https://github.com/paralleldrive/cuid has been deprecated and we have to use https://github.com/paralleldrive/cuid2 instead.

## Breaking change?

I assume `warehouse` uses `cuid` to generate post id. So, all of the post ids in `db.json` will be changed if we merge this PR. I think the posts ids are not on the premise that permanently stored (If hexo has to store ids permanently, should use RDB). But this change may be a breaking change for some users if they are using any plugin and it depends on that premise.

---

Closes: https://github.com/hexojs/warehouse/pull/146