### PR TITLE
fix(types/integer): use `Number.isInteger` for validating a value is an integer or not

### DIFF
--- a/src/types/integer.ts
+++ b/src/types/integer.ts
@@ -29,11 +29,11 @@ class SchemaTypeInteger extends SchemaTypeNumber {
   validate(value_?, data?): number {
     const value = super.validate(value_, data);
 
-    if (value % 1 !== 0) {
+    if (!Number.isInteger(value)) {
       throw new ValidationError(`\`${value}\` is not an integer!`);
     }
 
-    return value;
+    return value as number;
   }
 }
 


### PR DESCRIPTION
This PR is fix for `TS2362` & `TS2322` errors. We are facing  `TS2362` & `TS2322`  errors when we run `npm run eslint`.

```sh
> warehouse@5.0.0 preeslint
> npm run clean && npm run build

> warehouse@5.0.0 clean
> tsc -b --clean

> warehouse@5.0.0 build
> tsc -b

Error: src/types/integer.ts(32,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
Error: src/types/integer.ts(36,5): error TS2322: Type 'unknown' is not assignable to type 'number'.
Error: Process completed with exit code 1.
```

Thank you :)
