### PR TITLE
chore: use `prepublishOnly` instead of `prepublish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist/"
   ],
   "scripts": {
-    "prepublish ": "npm install && npm run clean && npm run build",
+    "prepublishOnly": "npm install && npm run clean && npm run build",
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "preeslint": "npm run clean && npm run build",


### PR DESCRIPTION
`prepublish` has been [deprecated](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts).

Thanks :)