### PR TITLE
refactor(export): use createWriteStream to export json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-config-hexo": "^5.0.0",
     "lodash": "^4.17.21",
     "mocha": "^11.0.1",
-    "sinon": "^17.0.1",
+    "sinon": "^19.0.2",
     "ts-node": "^10.9.1",
     "typedoc": "^0.27.2",
     "typedoc-plugin-rename-defaults": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint src test",
-    "test": "mocha -r ts-node/register 'test/scripts/**/*.ts'",
+    "test": "mocha -r ts-node/register test/scripts/**/*.ts",
     "test-cov": "c8 --reporter=lcovonly --reporter=text-summary npm test",
     "typedoc": "typedoc --entryPointStrategy expand ./src"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint src test",
-    "test": "mocha -r ts-node/register test/scripts/**/*.ts",
+    "test": "mocha -r ts-node/register 'test/scripts/**/*.ts'",
     "test-cov": "c8 --reporter=lcovonly --reporter=text-summary npm test",
     "typedoc": "typedoc --entryPointStrategy expand ./src"
   },
@@ -52,7 +52,7 @@
     "eslint": "^8.26.0",
     "eslint-config-hexo": "^5.0.0",
     "lodash": "^4.17.21",
-    "mocha": "^11.0.1",
+    "mocha": "11.0.2",
     "sinon": "^19.0.2",
     "ts-node": "^10.9.1",
     "typedoc": "^0.27.2",

--- a/src/database.ts
+++ b/src/database.ts
@@ -55,9 +55,7 @@ async function exportAsync(database: Database, path: string): Promise<void> {
     }
   } finally {
     await new Promise<void>((resolve, reject) => {
-      writeStream.end(() => {
-        resolve();
-      });
+      writeStream.end(resolve);
     });
   }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,6 +1,6 @@
 import { parse as createJsonParseStream } from './lib/jsonstream';
 import BluebirdPromise from 'bluebird';
-import { promises as fsPromises, createReadStream } from 'graceful-fs';
+import { createReadStream, createWriteStream } from 'graceful-fs';
 import { pipeline, Stream } from 'stream';
 import Model from './model';
 import Schema from './schema';
@@ -8,40 +8,41 @@ import SchemaType from './schematype';
 import WarehouseError from './error';
 import { logger } from 'hexo-log';
 import type { AddSchemaTypeOptions, NodeJSLikeCallback } from './types';
+import { asyncWriteToStream } from './util';
 
 const log = logger();
 const pkg = require('../package.json');
-const { open } = fsPromises;
 const pipelineAsync = BluebirdPromise.promisify(pipeline) as unknown as (...args: Stream[]) => BluebirdPromise<unknown>;
 
 async function exportAsync(database: Database, path: string): Promise<void> {
-  const handle = await open(path, 'w');
+  const writeStream = createWriteStream(path, { flags: 'w' });
 
   try {
+    let p: Promise<unknown> | undefined;
     // Start body & Meta & Start models
-    await handle.write(`{"meta":${JSON.stringify({
+    p = asyncWriteToStream(writeStream, `{"meta":${JSON.stringify({
       version: database.options.version,
       warehouse: pkg.version
     })},"models":{`);
+    if (p) await p;
 
     const models = database._models;
     const keys = Object.keys(models);
     const { length } = keys;
-
     // models body
     for (let i = 0; i < length; i++) {
       const key = keys[i];
 
       if (!models[key]) continue;
 
-      let prefix = '';
-      if (i) {
-        prefix = ',';
-      }
-      await handle.write(`${prefix}"${key}":${models[key]._export()}`);
+      const prefix = i ? ',' : '';
+      p = asyncWriteToStream(writeStream, `${prefix}"${key}":`);
+      if (p) await p;
+      await models[key].toJSONStream(writeStream);
     }
     // End models
-    await handle.write('}}');
+    p = asyncWriteToStream(writeStream, '}}');
+    if (p) await p;
   } catch (e) {
     log.error(e);
     if (e instanceof RangeError && e.message.includes('Invalid string length')) {
@@ -53,7 +54,11 @@ async function exportAsync(database: Database, path: string): Promise<void> {
       throw e;
     }
   } finally {
-    await handle.close();
+    await new Promise<void>((resolve, reject) => {
+      writeStream.end(() => {
+        resolve();
+      });
+    });
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,6 @@
+import { once } from 'node:events';
+import type { Writable } from 'node:stream';
+
 function extractPropKey(key: string): string[] {
   return key.split('.');
 }
@@ -190,4 +193,25 @@ export function parseArgs<B extends string | Record<string, number | Record<stri
   }
 
   return result;
+}
+
+/**
+ * A small utility function for writing chunk to a stream, and only return promise when needed (stream backpressure)
+ *
+ * ```ts
+ * const writeStream = fs.createWriteStream(outputFile);
+ * for (const line of source) {
+ *   const p = asyncWriteToStream(writeStream, line + '\n');
+ *   if (p) {
+ *     // eslint-disable-next-line no-await-in-loop -- stream backpressure
+ *     await p;
+ *   }
+ * }
+ */
+export function asyncWriteToStream<T>(stream: Writable, chunk: T): Promise<unknown> | null {
+  const waitDrain = !stream.write(chunk);
+  if (waitDrain) {
+    return once(stream, 'drain');
+  }
+  return null;
 }


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description

I'm wondering why you don't just splice the strings when exporting? It's faster and takes less memory.
before
![{06AA44C6-E458-43BE-929D-E9006A14191C}](https://github.com/user-attachments/assets/5d96aec2-d8e1-457b-926a-c1abae36c58a)
![{200754C4-1DE4-4149-AE1D-CC8069ECA165}](https://github.com/user-attachments/assets/3e0c49cc-f936-4381-9de6-2081b2812893)
You can see the memory rise at the end of `hexo g`.
after
![{D5249C5F-668C-482D-845B-45133F9ED3C1}](https://github.com/user-attachments/assets/5e41a446-d97b-42c8-9342-8008a0864bda)
![{F14BF233-E8C8-4D04-A85E-C684E15436EA}](https://github.com/user-attachments/assets/3d0f5b16-43da-422a-8e6a-f0cbdf8aacc4)

## Additional information
